### PR TITLE
Update xcom.py

### DIFF
--- a/xcom/xcom.py
+++ b/xcom/xcom.py
@@ -60,12 +60,12 @@ def calculate_attenuation(material: Material, energy: np.ndarray = None):
         atom_weights_amu = MaterialFactory.get_elements_mass_list(material.elements_by_Z)
         data = calculate_cross_section(material.elements_by_Z[0], energy)
         for name in data.dtype.names:
-            data[name] *= ( material.weights[0] * _AVOGADRO / atom_weights_amu[0])
+            if name != "energy": data[name] *= ( material.weights[0] * _AVOGADRO / atom_weights_amu[0])
 
         for atom_weight_amu, element, weight in zip(atom_weights_amu[1:], material.elements_by_Z[1:], material.weights):
             temp = calculate_cross_section(element, energy)
             for name in data.dtype.names:
-                data[name] +=  temp[name] * weight * _AVOGADRO / atom_weight_amu
+                if name != "energy": data[name] +=  temp[name] * weight * _AVOGADRO / atom_weight_amu
         return data
     else:
         raise Exception("Empty material")


### PR DESCRIPTION
In the one-material case for the calculate_attenuation method, a check is made to see if the name being modified is the energies for which mass attenuation coefficients are tabulated. If so, these energies are not scaled by the cross-section scaling factors. This is the correct behavior and gives correct results.

However, this check isn't being done for the multiple mixture case. For example. xcom.calculate_attenuation(xcom.Mixture([92, 92], [0.5,0.5]), [1e6])['energy'] didn't return 1 000 000 - it returned something like 35 000 (don't have the logs on me right now).

Altering the code to check if the name being altered is "energy" fixes this problem.